### PR TITLE
chore(db): Set up local PostgreSQL with Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  postgres-db:
+    image: postgres:16
+    container_name: budify-db
+    environment:
+      - POSTGRES_USER=budifyadmin
+      - POSTGRES_PASSWORD=myscretpassword
+      - POSTGRES_DB=budify
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
This PR introduces a `docker-compose.yml` file to run a PostgreSQL 16 container for local development.

This change ensures a consistent and isolated database environment for all developers working on the project.