### PR TITLE
fix: Correct Financial Summary Balance Calculation

### DIFF
--- a/Budgify.Application/Services/FinancialSummaryService.cs
+++ b/Budgify.Application/Services/FinancialSummaryService.cs
@@ -7,25 +7,31 @@ namespace Budgify.Application.Services
     {
         public readonly IIncomeRepository _incomeRepository;
         public readonly IExpenseRepository _expenseRepository;
+        public readonly IAccountRepository _accountRepository;
 
-        public FinancialSummaryService(IIncomeRepository incomeRepository, IExpenseRepository expenseRepository)
+        public FinancialSummaryService(IIncomeRepository incomeRepository, IExpenseRepository expenseRepository, IAccountRepository accountRepository)
         {
             _incomeRepository = incomeRepository;
             _expenseRepository = expenseRepository;
+            _accountRepository = accountRepository;
         }
 
         public FinancialSummaryDto GetSummary()
         {
             var incomes = _incomeRepository.GetAll();
             var expenses = _expenseRepository.GetAll();
+            var account = _accountRepository.GetAll();
 
             decimal totalIncome = incomes.Sum(i => i.Amount);
             decimal totalExpense = expenses.Sum(e => e.Amount);
+
+            decimal currentBalance = account.Sum(a => a.Balance);
+
             return new FinancialSummaryDto
             {
                 TotalIncome = totalIncome,
                 TotalExpense = totalExpense,
-                Balance = totalIncome - totalExpense
+                Balance = currentBalance
             };
         }
     }

--- a/Budgify.ConsoleApp/Program.cs
+++ b/Budgify.ConsoleApp/Program.cs
@@ -13,7 +13,7 @@ ICreditCardRepository cardRepository = new InMemoryCreditCardRepository();
 IAccountService accountService = new AccountService(accountRepository);
 IIncomeService incomeService = new IncomeService(incomeRepository, accountRepository);
 IExpenseService expenseService = new ExpenseService(expenseRepository, accountRepository, cardRepository);
-IFinancialSummaryService summaryService = new FinancialSummaryService(incomeRepository, expenseRepository);
+IFinancialSummaryService summaryService = new FinancialSummaryService(incomeRepository, expenseRepository, accountRepository);
 ICreditCardService cardService = new CreditCardService(cardRepository, accountRepository, expenseRepository);
 
 MainMenuScreen main = new MainMenuScreen(accountService, incomeService, expenseService, summaryService, cardService);


### PR DESCRIPTION
This PR fixes a logic bug in the Financial Summary where the Initial Balance of accounts was being ignored.

### The Bug:
Previously, `Balance` was calculated as `TotalIncome - TotalExpense`. This resulted in an incorrect balance if the user started with an initial amount but had no transactions.

### The Fix:
- **Service:** Injected `IAccountRepository` into `FinancialSummaryService`.
- **Logic:** The `Balance` property now sums the actual `Balance` property from all `Account` entities, which acts as the single source of truth (Rich Domain Model).
- **DI:** Updated `Program.cs` to support the new dependency.

